### PR TITLE
Feat/#14 oauth

### DIFF
--- a/apps/backend/src/config/config.py
+++ b/apps/backend/src/config/config.py
@@ -6,6 +6,12 @@ class Settings(BaseSettings):
     SECRET_KEY : str
     ALGORITHM : str
     BACKEND_CORS_ORIGINS: list = ["http://localhost:3000", "http://localhost:5173"]
+    FRONTEND_URL:str
+    GOOGLE_CLIENT_ID:str
+    GOOGLE_CLIENT_SECRET:str
+    REDIRECT_URI:str
+    META_ID:str
+    META_SECRET:str
 
     S3_ENDPOINT : str
     S3_ACCESS_KEY : str

--- a/apps/backend/src/core/entities/user_entities.py
+++ b/apps/backend/src/core/entities/user_entities.py
@@ -9,6 +9,10 @@ class UserRole(str,Enum):
     USER = "user"
     ADMIN = "admin"
 
+class OAuthProvider(str,Enum):
+    GOOGLE='google'
+    META='meta'
+    
 class User(BaseModel):
     id: UUID
     username: str
@@ -46,5 +50,11 @@ class UserUpdate(BaseModel):
     role: Optional[UserRole] = None
 
 # we need oAuth class
+
+class OAuthUser(BaseModel):
+    email:str
+    username: str
+    provider_id:str
+    provider:OAuthProvider
 
 

--- a/apps/backend/src/core/repo/user_repo.py
+++ b/apps/backend/src/core/repo/user_repo.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import List, Optional
-from ..entities.user_entities import User, UserCreate, UserUpdate, InternalUser
+from ..entities.user_entities import OAuthUser, User, UserCreate, UserUpdate, InternalUser
 
 class UserRepo(ABC):
     @abstractmethod
@@ -29,4 +29,15 @@ class UserRepo(ABC):
     
     @abstractmethod
     async def delete_user(self, user_id: str) -> bool:
+        ...
+
+
+
+class OAuthRepo(ABC):
+    @abstractmethod
+    async def create_or_update_oauth_user(self, oauth_user: OAuthUser) -> User:
+        ...
+    
+    @abstractmethod
+    async def get_user_by_oauth(self, provider: str, provider_id: str) -> Optional[User]:
         ...

--- a/apps/backend/src/infrastructure/providers/auth_provider.py
+++ b/apps/backend/src/infrastructure/providers/auth_provider.py
@@ -2,10 +2,12 @@ from functools import lru_cache
 from sqlalchemy.orm import Session
 from ...utils.security import SecurityManager
 from ...config.config import settings
-
+from ...utils.oauth import OAuthManager
 @lru_cache()
 def get_security_manager() -> SecurityManager:
     return SecurityManager(
         secret_key=settings.SECRET_KEY,
         algorithm=settings.ALGORITHM
     )
+def get_oauth_manager()->OAuthManager:
+    return OAuthManager()

--- a/apps/backend/src/infrastructure/repo/user_repo.py
+++ b/apps/backend/src/infrastructure/repo/user_repo.py
@@ -1,9 +1,9 @@
 from typing import Optional, List
 from sqlalchemy.orm import Session
-from ...core.repo.user_repo import UserRepo
-from ...core.entities.user_entities import User, UserCreate, UserUpdate, InternalUser
-from ..models.user_models import UserModel, UserRole
-
+from ...core.repo.user_repo import OAuthRepo, UserRepo
+from ...core.entities.user_entities import OAuthUser, User, UserCreate, UserUpdate, InternalUser
+from ..models.user_models import OAuthModel, UserModel, UserRole
+from sqlalchemy import and_
 class SQLUserRepo(UserRepo):
     def __init__(self, db: Session):
         self.db = db
@@ -38,3 +38,69 @@ class SQLUserRepo(UserRepo):
     
     async def delete_user(self, user_id: str) -> bool:
         ...
+
+
+class SQLOAuthRepo(OAuthRepo):
+    def __init__(self, db: Session):
+        self.db = db
+
+    async def create_or_update_oauth_user(self, oauth_user: OAuthUser) -> User:
+        #  Check if OAuth entry exists
+        oauth_entry = (
+            self.db.query(OAuthModel)
+            .filter(
+                and_(
+                    OAuthModel.provider == oauth_user.provider,
+                    OAuthModel.provider_id == oauth_user.provider_id,
+                )
+            )
+            .first()
+        )
+
+        if oauth_entry:
+            # OAuth entry exists → return associated user
+            return User.model_validate(oauth_entry.user)
+
+        #  Try finding an existing user with the same email
+        user = self.db.query(UserModel).filter(UserModel.email == oauth_user.email).first()
+
+        if not user:
+            #  Create new user
+            user = UserModel(
+                email=oauth_user.email,
+                username=oauth_user.username,
+                hash_password="", 
+                role=UserRole.user,
+                is_verified=True 
+            )
+            self.db.add(user)
+            self.db.flush()  # Ensure user ID is available for FK
+
+        #  Create new OAuthModel entry linked to the user
+        oauth_entry = OAuthModel(
+            user_id=user.id,
+            provider=oauth_user.provider,
+            provider_id=oauth_user.provider_id
+        )
+        self.db.add(oauth_entry)
+        self.db.commit()
+        self.db.refresh(user)
+
+        return User.model_validate(user)
+
+    async def get_user_by_oauth(self, provider: str, provider_id: str) -> Optional[User]:
+        oauth_entry = (
+            self.db.query(OAuthModel)
+            .filter(
+                and_(
+                    OAuthModel.provider == provider,
+                    OAuthModel.provider_id == provider_id
+                )
+            )
+            .first()
+        )
+
+        if not oauth_entry:
+            return None
+
+        return User.model_validate(oauth_entry.user)

--- a/apps/backend/src/interfaces/routes/auth_routes.py
+++ b/apps/backend/src/interfaces/routes/auth_routes.py
@@ -1,12 +1,14 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException
 from ..schemas.auth_schemas import RegisterSchema, LoginSchema
 from ..schemas.base_schemas import APIResponseSchema
 from ...utils.security import SecurityManager
-from ...infrastructure.providers.auth_provider import get_security_manager
+from ...infrastructure.providers.auth_provider import get_oauth_manager, get_security_manager
 from sqlalchemy.orm import Session
 from ...database.database import get_DB
-from ...infrastructure.repo.user_repo import SQLUserRepo
+from ...infrastructure.repo.user_repo import SQLOAuthRepo, SQLUserRepo
 from ...core.services.auth_service import AuthService
+from ...utils.oauth import OAuthManager
+from ...config.config import settings
 
 auth_router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -60,3 +62,44 @@ async def login_user(
         
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
+    
+
+@auth_router.get('/oauth/login')
+async def oauthLogin(
+    code: str,
+    state: str,
+    db: Session = Depends(get_DB),
+    security_manager: SecurityManager = Depends(get_security_manager),
+    oauth_manager: OAuthManager = Depends(get_oauth_manager)
+):
+    try:
+        # client = getattr(oauth, state)
+        # token = await client.authorize_access_token(request)
+        # if state == "google":
+        #     user_info = await client.get("userinfo", token=token)
+        # elif state == "meta":
+        #     user_info = await client.get("me?fields=id,name,email", token=token)
+        # else:
+        #     raise HTTPException(status_code=400, detail="User info endpoint not configured")
+        user_repo = SQLUserRepo(db)
+        oauth_repo = SQLOAuthRepo(db)
+        auth_service = AuthService(user_repo, security_manager,oauth_repo)
+
+        oauth_user = await oauth_manager.get_oauth_user(
+            provider=state,
+            code=code,
+            redirect_uri='http://localhost:8000/api/auth/oauth/login'
+        )
+        access_token, refresh_token, user = await auth_service.oauth_login(oauth_user)
+        return APIResponseSchema(
+            success=True,
+            data = {"user":user,"access_token":access_token, "refresh_token":refresh_token},
+            message="User logged in succesfully"
+        )
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))   
+    # return {
+    #     "code": code,
+    #     "state": state,
+    #     "user":user_info
+    #     }   

--- a/apps/backend/src/utils/oauth.py
+++ b/apps/backend/src/utils/oauth.py
@@ -1,0 +1,52 @@
+from .exceptions import AuthExceptionError
+from ..config.config import settings
+from authlib.integrations.httpx_client import AsyncOAuth2Client
+from ..core.entities.user_entities import OAuthProvider, OAuthUser
+
+class OAuthManager:
+    def __init__(self):
+        self.providers = {
+            OAuthProvider.GOOGLE: {
+                'client_id': settings.GOOGLE_CLIENT_ID,
+                'client_secret': settings.GOOGLE_CLIENT_SECRET,
+                'authorize_url': 'https://accounts.google.com/o/oauth2/auth',
+                'token_url': 'https://oauth2.googleapis.com/token',
+                'userinfo_url': 'https://www.googleapis.com/oauth2/v2/userinfo'
+            },
+            OAuthProvider.META: {
+                'client_id': settings.META_ID,
+                'client_secret': settings.META_SECRET,
+                'authorize_url': 'https://www.facebook.com/v18.0/dialog/oauth',  # latest Graph API version
+                'token_url': 'https://graph.facebook.com/v18.0/oauth/access_token',
+                'userinfo_url': 'https://graph.facebook.com/me?fields=id,name,email'
+            }
+        }
+    async def get_oauth_user(self, provider: OAuthProvider, code: str, redirect_uri: str) -> OAuthUser:
+        provider_config = self.providers[provider]
+        async with AsyncOAuth2Client(
+            client_id=provider_config['client_id'],
+            client_secret=provider_config['client_secret']
+        ) as client:
+            # Exchange code for token
+            token_response = await client.fetch_token(
+                provider_config['token_url'],
+                code=code,
+                redirect_uri=redirect_uri
+            )
+            userinfo_response = await client.get(
+                provider_config['userinfo_url'],
+                # token=token_response
+            )
+            if userinfo_response.status_code != 200:
+                raise AuthExceptionError(userinfo_response.status_code)
+            
+            user_data = userinfo_response.json()
+            if provider == OAuthProvider.GOOGLE:
+                return OAuthUser(
+                    email=user_data['email'],
+                    username=user_data['name'],
+                    provider=provider,
+                    provider_id=user_data['id']
+                )
+            raise AuthExceptionError(f"Unsupported OAuth provider: {provider}")
+

--- a/apps/backend/src/utils/oauth.py
+++ b/apps/backend/src/utils/oauth.py
@@ -41,12 +41,14 @@ class OAuthManager:
                 raise AuthExceptionError(userinfo_response.status_code)
             
             user_data = userinfo_response.json()
-            if provider == OAuthProvider.GOOGLE:
+            if provider in OAuthProvider:
                 return OAuthUser(
                     email=user_data['email'],
                     username=user_data['name'],
                     provider=provider,
                     provider_id=user_data['id']
                 )
+            
+
             raise AuthExceptionError(f"Unsupported OAuth provider: {provider}")
 

--- a/apps/frontend/src/routes/login/index.tsx
+++ b/apps/frontend/src/routes/login/index.tsx
@@ -5,7 +5,6 @@ import { Input } from "@/components/ui/input";
 import { useState } from "react";
 import doc from "@/assets/doc.png";
 import BubbleBackground from "@/components/common/BubbleBackground";
-
 export const Route = createFileRoute("/login/")({
   component: Login,
 });
@@ -13,7 +12,29 @@ export const Route = createFileRoute("/login/")({
 function Login() {
   const [showEmailInput, setShowEmailInput] = useState(false);
   const [email, setEmail] = useState("");
+  const handleOAuth = (e: React.MouseEvent<HTMLButtonElement>) => {
+    const provider = e.currentTarget.name as "google" | "meta";
+    const url =
+      provider === "meta"
+        ? `https://www.facebook.com/v20.0/dialog/oauth?` +
+          new URLSearchParams({
+            client_id: import.meta.env.VITE_META_ID,
+            redirect_uri: import.meta.env.VITE_REDIRECT_URI,
+            response_type: "code",
+            scope: "email,public_profile", // FB scopes
+            state: "meta",
+          })
+        : `https://accounts.google.com/o/oauth2/v2/auth?` +
+          new URLSearchParams({
+            client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID,
+            redirect_uri: import.meta.env.VITE_REDIRECT_URI,
+            response_type: "code",
+            scope: "openid email profile",
+            state: "google",
+          });
 
+    window.location.href = url;
+  };
   return (
     <div className="relative w-screen h-screen overflow-hidden bg-gradient-to-br from-[#3a0067] via-[#240046] to-[#18002B]">
       {/* === Bubble Background (non-interactive) === */}
@@ -37,8 +58,93 @@ function Login() {
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <Button type="submit" className="w-full">
-            Continue with Google
+          <Button
+            name="google"
+            className="w-full flex items-center gap-3  bg-blue-600 hover:bg-blue-700"
+            onClick={handleOAuth}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 48 48"
+              width="48px"
+              height="48px"
+            >
+              <path
+                fill="#FFC107"
+                d="M43.611,20.083H42V20H24v8h11.303c-1.649,4.657-6.08,8-11.303,8c-6.627,0-12-5.373-12-12c0-6.627,5.373-12,12-12c3.059,0,5.842,1.154,7.961,3.039l5.657-5.657C34.046,6.053,29.268,4,24,4C12.955,4,4,12.955,4,24c0,11.045,8.955,20,20,20c11.045,0,20-8.955,20-20C44,22.659,43.862,21.35,43.611,20.083z"
+              />
+              <path
+                fill="#FF3D00"
+                d="M6.306,14.691l6.571,4.819C14.655,15.108,18.961,12,24,12c3.059,0,5.842,1.154,7.961,3.039l5.657-5.657C34.046,6.053,29.268,4,24,4C16.318,4,9.656,8.337,6.306,14.691z"
+              />
+              <path
+                fill="#4CAF50"
+                d="M24,44c5.166,0,9.86-1.977,13.409-5.192l-6.19-5.238C29.211,35.091,26.715,36,24,36c-5.202,0-9.619-3.317-11.283-7.946l-6.522,5.025C9.505,39.556,16.227,44,24,44z"
+              />
+              <path
+                fill="#1976D2"
+                d="M43.611,20.083H42V20H24v8h11.303c-0.792,2.237-2.231,4.166-4.087,5.571c0.001-0.001,0.002-0.001,0.003-0.002l6.19,5.238C36.971,39.205,44,34,44,24C44,22.659,43.862,21.35,43.611,20.083z"
+              />
+            </svg>
+            <span>Sign in with Google</span>
+          </Button>
+
+          {/* Meta Continue */}
+          <Button
+            name="meta"
+            className="w-full flex items-center gap-3 bg-blue-600 hover:bg-blue-700 text-white"
+            onClick={handleOAuth}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 48 48"
+              width="48px"
+              height="48px"
+            >
+              <path
+                fill="#0081fb"
+                d="M47,29.36l-2.193,1.663L42.62,29.5c0-0.16,0-0.33-0.01-0.5c0-0.16,0-0.33-0.01-0.5	c-0.14-3.94-1.14-8.16-3.14-11.25c-1.54-2.37-3.51-3.5-5.71-3.5c-2.31,0-4.19,1.38-6.27,4.38c-0.06,0.09-0.13,0.18-0.19,0.28	c-0.04,0.05-0.07,0.1-0.11,0.16c-0.1,0.15-0.2,0.3-0.3,0.46c-0.9,1.4-1.84,3.03-2.86,4.83c-0.09,0.17-0.19,0.34-0.28,0.51	c-0.03,0.04-0.06,0.09-0.08,0.13l-0.21,0.37l-1.24,2.19c-2.91,5.15-3.65,6.33-5.1,8.26C14.56,38.71,12.38,40,9.51,40	c-3.4,0-5.56-1.47-6.89-3.69C1.53,34.51,1,32.14,1,29.44l4.97,0.17c0,1.76,0.38,3.1,0.89,3.92C7.52,34.59,8.49,35,9.5,35	c1.29,0,2.49-0.27,4.77-3.43c1.83-2.53,3.99-6.07,5.44-8.3l1.37-2.09l0.29-0.46l0.3-0.45l0.5-0.77c0.76-1.16,1.58-2.39,2.46-3.57	c0.1-0.14,0.2-0.28,0.31-0.42c0.1-0.14,0.21-0.28,0.31-0.41c0.9-1.15,1.85-2.22,2.87-3.1c1.85-1.61,3.84-2.5,5.85-2.5	c3.37,0,6.58,1.95,9.04,5.61c2.51,3.74,3.82,8.4,3.97,13.25c0.01,0.16,0.01,0.33,0.01,0.5C47,29.03,47,29.19,47,29.36z"
+              />
+              <linearGradient
+                id="wSMw7pqi7WIWHewz2_TZXa"
+                x1="42.304"
+                x2="13.533"
+                y1="24.75"
+                y2="24.75"
+                gradientUnits="userSpaceOnUse"
+              >
+                <stop offset="0" stop-color="#0081fb" />
+                <stop offset=".995" stop-color="#0064e1" />
+              </linearGradient>
+              <path
+                fill="url(#wSMw7pqi7WIWHewz2_TZXa)"
+                d="M4.918,15.456	C7.195,11.951,10.483,9.5,14.253,9.5c2.184,0,4.354,0.645,6.621,2.493c2.479,2.02,5.122,5.346,8.419,10.828l1.182,1.967	c2.854,4.746,4.477,7.187,5.428,8.339C37.125,34.606,37.888,35,39,35c2.82,0,3.617-2.54,3.617-5.501L47,29.362	c0,3.095-0.611,5.369-1.651,7.165C44.345,38.264,42.387,40,39.093,40c-2.048,0-3.862-0.444-5.868-2.333	c-1.542-1.45-3.345-4.026-4.732-6.341l-4.126-6.879c-2.07-3.452-3.969-6.027-5.068-7.192c-1.182-1.254-2.642-2.754-5.067-2.754	c-1.963,0-3.689,1.362-5.084,3.465L4.918,15.456z"
+              />
+              <linearGradient
+                id="wSMw7pqi7WIWHewz2_TZXb"
+                x1="7.635"
+                x2="7.635"
+                y1="32.87"
+                y2="13.012"
+                gradientUnits="userSpaceOnUse"
+              >
+                <stop offset="0" stop-color="#0081fb" />
+                <stop offset=".995" stop-color="#0064e1" />
+              </linearGradient>
+              <path
+                fill="url(#wSMw7pqi7WIWHewz2_TZXb)"
+                d="M14.25,14.5	c-1.959,0-3.683,1.362-5.075,3.465C7.206,20.937,6,25.363,6,29.614c0,1.753-0.003,3.072,0.5,3.886l-3.84,2.813	C1.574,34.507,1,32.2,1,29.5c0-4.91,1.355-10.091,3.918-14.044C7.192,11.951,10.507,9.5,14.27,9.5L14.25,14.5z"
+              />
+              <path
+                d="M21.67,20.27l-0.3,0.45l-0.29,0.46c0.71,1.03,1.52,2.27,2.37,3.69l0.21-0.37c0.02-0.04,0.05-0.09,0.08-0.13 c0.09-0.17,0.19-0.34,0.28-0.51C23.19,22.5,22.39,21.29,21.67,20.27z M24.94,15.51c-0.11,0.14-0.21,0.28-0.31,0.42 c0.73,0.91,1.47,1.94,2.25,3.1c0.1-0.16,0.2-0.31,0.3-0.46c0.04-0.06,0.07-0.11,0.11-0.16c0.06-0.1,0.13-0.19,0.19-0.28 c-0.76-1.12-1.5-2.13-2.23-3.03C25.15,15.23,25.04,15.37,24.94,15.51z"
+                opacity=".05"
+              />
+              <path
+                d="M21.67,20.27l-0.3,0.45c0.71,1.02,1.51,2.24,2.37,3.65c0.09-0.17,0.19-0.34,0.28-0.51C23.19,22.5,22.39,21.29,21.67,20.27 z M24.63,15.93c0.73,0.91,1.47,1.94,2.25,3.1c0.1-0.16,0.2-0.31,0.3-0.46c-0.77-1.14-1.52-2.16-2.24-3.06 C24.83,15.65,24.73,15.79,24.63,15.93z"
+                opacity=".07"
+              />
+            </svg>
+            <span>Continue with Meta</span>
           </Button>
           {!showEmailInput ? (
             <Button


### PR DESCRIPTION
# Implement OAuth Login for Google and Meta

## Description
This PR adds OAuth 2.0 login support for both **Google** and **Meta** authentication providers.

## Changes Introduced
- Added `OAuthProvider` enum with `GOOGLE` and `META` values.
- Implemented Google OAuth login flow.
- Implemented Meta OAuth login flow.
- Updated authentication routes to handle multiple OAuth providers (currently supported ones are GOOGLE and META).
- Added error handling for unsupported or invalid providers.

## Impact
- Users can now log in using Google or Meta (previously known as Facebook) accounts.
- Improves flexibility by supporting multiple OAuth providers in a single flow.
