### PR TITLE
Upload PDF to cloudinary and save download URL to postgres

### DIFF
--- a/apps/backend/.example.env
+++ b/apps/backend/.example.env
@@ -26,6 +26,10 @@ MAX_COUNT_FOR_USER=5
 
 VECTOR_MODEL="sentence-transformers/all-mpnet-base-v2"
 COHERE_API_KEY = ["your-cohere-api-key-here"]
+
+CLOUDINARY_CLOUD_NAME=<your-cloud-name>
+CLOUDINARY_API_KEY =<your-api-key>
+CLOUDINARY_API_SECRET=<your-api-secret>
 # =============================================================================
 # UNCOMMENT ONLY FOR LOCAL(DEV)
 # =============================================================================

--- a/apps/backend/.gitignore
+++ b/apps/backend/.gitignore
@@ -1,2 +1,5 @@
 .venv
 db-quries.sql
+client_secret_doclin.json
+doclin-note-generator-service.json
+doclin-firebase-service-account.json

--- a/apps/backend/requirements-prod.txt
+++ b/apps/backend/requirements-prod.txt
@@ -41,3 +41,4 @@ json-repair==0.50.0
 
 sib-api-v3-sdk==7.6.0
 cohere==5.18.0
+cloudinary==1.44.1

--- a/apps/backend/requirements.txt
+++ b/apps/backend/requirements.txt
@@ -43,3 +43,5 @@ json-repair==0.50.0
 
 sib-api-v3-sdk==7.6.0
 cohere==5.18.0
+
+cloudinary==1.44.1

--- a/apps/backend/src/config/config.py
+++ b/apps/backend/src/config/config.py
@@ -59,6 +59,9 @@ class Settings(BaseSettings):
     # Paid model toggle
     ALLOW_PAID_MODELS: bool = False
 
+    CLOUDINARY_CLOUD_NAME : str
+    CLOUDINARY_API_KEY : str
+    CLOUDINARY_API_SECRET : str
     PORT: int = 8000  
 
     @classmethod

--- a/apps/backend/src/core/entities/previous_year_paper_entities.py
+++ b/apps/backend/src/core/entities/previous_year_paper_entities.py
@@ -10,6 +10,9 @@ class PreviousYearPaper(BaseModel):
     paper_name:str
     year:int
     file_url:str
+    filename:str
+    public_id:str
+    uploaded_by:UUID
     created_at:datetime
     updated_at:datetime
     class Config:
@@ -22,3 +25,6 @@ class PreviousYearPaperAdd(BaseModel):
     paper_name:str
     year:int
     file_url:str
+    filename:str
+    public_id:str
+    uploaded_by:UUID

--- a/apps/backend/src/core/entities/previous_year_paper_entities.py
+++ b/apps/backend/src/core/entities/previous_year_paper_entities.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel
+from uuid import UUID
+from datetime import datetime
+
+class PreviousYearPaper(BaseModel):
+    id:UUID
+    board:str
+    subject:str
+    paper_code:str
+    paper_name:str
+    year:int
+    file_url:str
+    created_at:datetime
+    updated_at:datetime
+    class Config:
+        from_attributes = True
+
+class PreviousYearPaperAdd(BaseModel):
+    board:str
+    subject:str
+    paper_code:str
+    paper_name:str
+    year:int
+    file_url:str

--- a/apps/backend/src/core/repo/previous_year_paper_repo.py
+++ b/apps/backend/src/core/repo/previous_year_paper_repo.py
@@ -1,0 +1,12 @@
+from abc import ABC, abstractmethod
+from typing import List
+from ...core.entities.previous_year_paper_entities import PreviousYearPaperAdd,PreviousYearPaper
+
+class PreviousYearPaperRepo(ABC):
+    @abstractmethod
+    async def add_pdf_url(self,info:PreviousYearPaperAdd)->PreviousYearPaper:
+        ...
+        
+    @abstractmethod
+    async def get_all_pdf(self,skip: int, limit: int = 100 )-> List[PreviousYearPaper]:
+        ...

--- a/apps/backend/src/core/repo/previous_year_paper_repo.py
+++ b/apps/backend/src/core/repo/previous_year_paper_repo.py
@@ -10,3 +10,8 @@ class PreviousYearPaperRepo(ABC):
     @abstractmethod
     async def get_all_pdf(self,skip: int, limit: int = 100 )-> List[PreviousYearPaper]:
         ...
+
+    @abstractmethod
+    async def delete_pdf(self,id:str )-> bool:
+        ...
+

--- a/apps/backend/src/core/services/file_uplaod_service.py
+++ b/apps/backend/src/core/services/file_uplaod_service.py
@@ -1,0 +1,39 @@
+from http.client import HTTPException
+import os
+import shutil
+import cloudinary
+import cloudinary.uploader
+from fastapi import UploadFile, File
+from ...config.config import settings
+class FileUploadService:
+    def __init__(self):
+        self.cloud_name = settings.CLOUDINARY_CLOUD_NAME
+        self.api_key = settings.CLOUDINARY_API_KEY
+        self.api_secret = settings.CLOUDINARY_API_SECRET
+        self.upload_dir = "temp_uploads"
+        os.makedirs(self.upload_dir, exist_ok=True)
+        cloudinary.config(
+            cloud_name=self.cloud_name,
+            api_key=self.api_key,
+            api_secret=self.api_secret,
+            secure=True
+        )   
+    async def upload_file(self, file: UploadFile = File(...)) -> str:
+        temp_file_path = os.path.join(self.upload_dir, file.filename)
+        try:
+            with open(temp_file_path, "wb") as buffer:
+                shutil.copyfileobj(file.file, buffer)
+        finally:
+            file.file.close()
+        try:
+            upload_result = cloudinary.uploader.upload(temp_file_path,resource_type="image", 
+            folder="pdf_uploads",
+            public_id=os.path.splitext(file.filename)[0],
+            eager=[{"format": "jpg", "page": 1, "width": 500}], 
+            eager_async=False,)
+            file_url = upload_result.get("secure_url")
+            return file_url
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=str(e))
+        finally:
+            os.remove(temp_file_path)

--- a/apps/backend/src/core/services/file_uplaod_service.py
+++ b/apps/backend/src/core/services/file_uplaod_service.py
@@ -4,7 +4,7 @@ import shutil
 import cloudinary
 import cloudinary.uploader
 from fastapi import UploadFile, File
-from ...utils.exceptions import InternelServerException
+from ...utils.exceptions import InternelServerException, LargePayloadException
 from ...config.config import settings
 class FileUploadService:
     def __init__(self):
@@ -12,6 +12,8 @@ class FileUploadService:
         self.api_key = settings.CLOUDINARY_API_KEY
         self.api_secret = settings.CLOUDINARY_API_SECRET
         self.upload_dir = "temp_uploads"
+        self.MAX_FILE_SIZE_MB = 5
+        self.MAX_FILE_SIZE = self.MAX_FILE_SIZE_MB * 1024 * 1024
         os.makedirs(self.upload_dir, exist_ok=True)
         cloudinary.config(
             cloud_name=self.cloud_name,
@@ -22,14 +24,21 @@ class FileUploadService:
     async def upload_file(self, file: UploadFile = File(...)) -> str:
         temp_file_path = os.path.join(self.upload_dir, file.filename)
         try:
+            contents = await file.read()
+            if len(contents) > self.MAX_FILE_SIZE:
+                raise LargePayloadException(
+                    detail=f"File size exceeds {self.MAX_FILE_SIZE_MB} MB limit"
+                )
+
             with open(temp_file_path, "wb") as buffer:
-                shutil.copyfileobj(file.file, buffer)
+                buffer.write(contents)
         finally:
             file.file.close()
         try:
             upload_result = cloudinary.uploader.upload(temp_file_path,resource_type="image", 
             folder="pdf_uploads",
-            public_id=os.path.splitext(file.filename)[0],
+            use_filename=True,
+            unique_filename=True,
             eager=[{"format": "jpg", "page": 1, "width": 500}], 
             eager_async=False,)
             file_url = upload_result.get("secure_url")

--- a/apps/backend/src/core/services/file_uplaod_service.py
+++ b/apps/backend/src/core/services/file_uplaod_service.py
@@ -1,10 +1,9 @@
 
 import os
-import shutil
 import cloudinary
 import cloudinary.uploader
 from fastapi import UploadFile, File
-from ...utils.exceptions import InternelServerException, LargePayloadException
+from ...utils.exceptions import InternelServerException, LargePayloadException, NotFoundExceptionError
 from ...config.config import settings
 class FileUploadService:
     def __init__(self):
@@ -21,7 +20,8 @@ class FileUploadService:
             api_secret=self.api_secret,
             secure=True
         )   
-    async def upload_file(self, file: UploadFile = File(...)) -> str:
+
+    async def upload_file(self, file: UploadFile = File(...)) :
         temp_file_path = os.path.join(self.upload_dir, file.filename)
         try:
             contents = await file.read()
@@ -42,8 +42,22 @@ class FileUploadService:
             eager=[{"format": "jpg", "page": 1, "width": 500}], 
             eager_async=False,)
             file_url = upload_result.get("secure_url")
-            return file_url
+            return {
+                "file_url": file_url,
+                "asset_id": upload_result["asset_id"],
+                "public_id":upload_result["public_id"]
+}
         except Exception as e:
             raise InternelServerException(f"File upload failed: {str(e)}")
         finally:
             os.remove(temp_file_path)
+
+
+    async def delete_file(self,id:str)->bool:
+        try:
+            result = cloudinary.uploader.destroy(id)
+            if result != "ok":
+                raise NotFoundExceptionError('File is missing')
+            return True
+        except Exception as e:
+            raise InternelServerException( detail=str(e))

--- a/apps/backend/src/core/services/file_uplaod_service.py
+++ b/apps/backend/src/core/services/file_uplaod_service.py
@@ -1,9 +1,10 @@
-from http.client import HTTPException
+
 import os
 import shutil
 import cloudinary
 import cloudinary.uploader
 from fastapi import UploadFile, File
+from ...utils.exceptions import InternelServerException
 from ...config.config import settings
 class FileUploadService:
     def __init__(self):
@@ -34,6 +35,6 @@ class FileUploadService:
             file_url = upload_result.get("secure_url")
             return file_url
         except Exception as e:
-            raise HTTPException(status_code=500, detail=str(e))
+            raise InternelServerException(f"File upload failed: {str(e)}")
         finally:
             os.remove(temp_file_path)

--- a/apps/backend/src/core/services/otp_service.py
+++ b/apps/backend/src/core/services/otp_service.py
@@ -1,5 +1,5 @@
 from ...core.entities.otp_entities import OTP, OTPCreate
-from ...infrastructure.models.otp_models import OTPModel
+
 from ...utils.exceptions import InternelServerException, NotFoundExceptionError,ValidationExceptionError
 from ...utils.security import SecurityManager
 from ..repo.otp_repo import OTPRepo
@@ -27,7 +27,7 @@ class OTPService:
             otp_entry:OTP=  await self.otp_repo.create_or_update_otp( otp=otp_)
             return otp,otp_entry
         except Exception as e:
-            raise InternelServerException()
+            raise InternelServerException(detail=str(e))
         
     async def get_otp_entry(self,email:str)->Optional[OTP]:
         otp_data=await self.otp_repo.get_otp_by_email(email)

--- a/apps/backend/src/core/services/previous_year_paper_service.py
+++ b/apps/backend/src/core/services/previous_year_paper_service.py
@@ -1,4 +1,6 @@
 from typing import List
+
+from ...utils.exceptions import InternelServerException
 from ...core.entities.previous_year_paper_entities import PreviousYearPaper, PreviousYearPaperAdd
 from ...core.repo.previous_year_paper_repo import PreviousYearPaperRepo
 
@@ -7,8 +9,26 @@ class previousYearPaperService:
     def __init__(self,prev_year_paper_repo=PreviousYearPaperRepo):
         self.prev_year_paper_repo = prev_year_paper_repo
     async def add_pdf_url(self,info:PreviousYearPaperAdd)->PreviousYearPaper:
-        return await self.prev_year_paper_repo.add_pdf_url(info)
-    async def get_all_pdf(self,skip:int,limit:int=100)->List[PreviousYearPaper]:
-        files= await self.prev_year_paper_repo.get_all_pdf(skip,limit)
-        return [PreviousYearPaper.model_validate(file) for file in files]
+        try:
+            return await self.prev_year_paper_repo.add_pdf_url(info)
+        except Exception as e:
+            raise InternelServerException(detail=str(e))
     
+    
+    async def get_all_pdf(self,skip:int,limit:int=100)->List[PreviousYearPaper]:  
+        try:
+            files= await self.prev_year_paper_repo.get_all_pdf(skip,limit)
+            return [PreviousYearPaper.model_validate(file) for file in files]
+        except Exception as e:
+            raise InternelServerException(detail=str(e))
+        
+
+    async def delete_pdf(self,id: str)->bool:
+        try:
+            deleted= await self.prev_year_paper_repo.delete_pdf(id)
+            if not deleted:
+                raise InternelServerException('Unable to delete the entry from database')
+            return True
+        except Exception as e:
+            raise InternelServerException(detail=str(e))
+        

--- a/apps/backend/src/core/services/previous_year_paper_service.py
+++ b/apps/backend/src/core/services/previous_year_paper_service.py
@@ -1,0 +1,14 @@
+from typing import List
+from ...core.entities.previous_year_paper_entities import PreviousYearPaper, PreviousYearPaperAdd
+from ...core.repo.previous_year_paper_repo import PreviousYearPaperRepo
+
+
+class previousYearPaperService:
+    def __init__(self,prev_year_paper_repo=PreviousYearPaperRepo):
+        self.prev_year_paper_repo = prev_year_paper_repo
+    async def add_pdf_url(self,info:PreviousYearPaperAdd)->PreviousYearPaper:
+        return await self.prev_year_paper_repo.add_pdf_url(info)
+    async def get_all_pdf(self,skip:int,limit:int=100)->List[PreviousYearPaper]:
+        files= await self.prev_year_paper_repo.get_all_pdf(skip,limit)
+        return [PreviousYearPaper.model_validate(file) for file in files]
+    

--- a/apps/backend/src/infrastructure/models/__init__.py
+++ b/apps/backend/src/infrastructure/models/__init__.py
@@ -2,3 +2,4 @@ from .feedback_models import FeedbackModel
 from .exam_paper_models import ExamPaperModel
 from .otp_models import OTPModel
 from .user_models import UserModel
+from .previous_year_papers_model import PreviousYearPaperModel

--- a/apps/backend/src/infrastructure/models/previous_year_papers_model.py
+++ b/apps/backend/src/infrastructure/models/previous_year_papers_model.py
@@ -1,9 +1,9 @@
 from datetime import datetime, timezone
 from uuid import uuid4
-from sqlalchemy import Column, String, Integer, DateTime
+from sqlalchemy import Column, String, Integer, DateTime,ForeignKey
 
 from sqlalchemy.dialects.postgresql import UUID
- 
+from sqlalchemy.orm import relationship
 
 from ...database.database import Base
 
@@ -12,12 +12,18 @@ class PreviousYearPaperModel(Base):
     __tablename__ = "previous_year_papers"
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+
     board = Column(String, nullable=False, default="ICSE")
     subject = Column(String, nullable=False)
     paper_name = Column(String, nullable=False)
     paper_code = Column(String, nullable=False)
     year = Column(Integer, nullable=False)
+
     file_url = Column(String, nullable=False)
+    filename = Column(String, nullable=False)
+    public_id = Column(String, nullable=False)
+
+    uploaded_by = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
     
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
     updated_at = Column(
@@ -25,4 +31,5 @@ class PreviousYearPaperModel(Base):
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
     )
+    user = relationship("UserModel", back_populates="previous_year_papers")
 

--- a/apps/backend/src/infrastructure/models/previous_year_papers_model.py
+++ b/apps/backend/src/infrastructure/models/previous_year_papers_model.py
@@ -1,8 +1,7 @@
 from datetime import datetime, timezone
 from uuid import uuid4
-from sqlalchemy import (
-    Column, String, Integer, DateTime,
-)
+from sqlalchemy import Column, String, Integer, DateTime
+
 from sqlalchemy.dialects.postgresql import UUID
  
 

--- a/apps/backend/src/infrastructure/models/previous_year_papers_model.py
+++ b/apps/backend/src/infrastructure/models/previous_year_papers_model.py
@@ -1,0 +1,29 @@
+from datetime import datetime, timezone
+from uuid import uuid4
+from sqlalchemy import (
+    Column, String, Integer, DateTime,
+)
+from sqlalchemy.dialects.postgresql import UUID
+ 
+
+from ...database.database import Base
+
+
+class PreviousYearPaperModel(Base):
+    __tablename__ = "previous_year_papers"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    board = Column(String, nullable=False, default="ICSE")
+    subject = Column(String, nullable=False)
+    paper_name = Column(String, nullable=False)
+    paper_code = Column(String, nullable=False)
+    year = Column(Integer, nullable=False)
+    file_url = Column(String, nullable=False)
+    
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(
+        DateTime,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+

--- a/apps/backend/src/infrastructure/models/user_models.py
+++ b/apps/backend/src/infrastructure/models/user_models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, Boolean, DateTime, Enum, ForeignKey,Integer,Float
+from sqlalchemy import Column, String, Boolean, DateTime, Enum, ForeignKey,Integer
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from datetime import datetime, timezone
@@ -33,7 +33,7 @@ class UserModel(Base):
 
     oauth_accounts = relationship("OAuthModel", back_populates="user")
     feedbacks = relationship("FeedbackModel", back_populates="user", cascade="all, delete-orphan")
-
+    previous_year_papers=relationship("PreviousYearPaperModel", back_populates="user", cascade="all, delete-orphan")
 
 class OAuthModel(Base):
     __tablename__ = "oauth_accounts"
@@ -45,15 +45,3 @@ class OAuthModel(Base):
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
 
     user = relationship("UserModel", back_populates="oauth_accounts")
-# class FeedbackModel(Base):
-#     __tablename__ = "feedbacks"
-
-#     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-#     user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
-#     rating = Column(Float, nullable=False)
-#     feedback_text = Column(String, nullable=True)
-
-#     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
-
-
-#     user = relationship("UserModel", back_populates="feedbacks")

--- a/apps/backend/src/infrastructure/repo/previous_year_papers_repo.py
+++ b/apps/backend/src/infrastructure/repo/previous_year_papers_repo.py
@@ -1,0 +1,28 @@
+from typing import List
+from sqlalchemy.orm import Session
+from ...core.entities.previous_year_paper_entities import PreviousYearPaper, PreviousYearPaperAdd
+from ...infrastructure.models.previous_year_papers_model import PreviousYearPaperModel
+from ...core.repo.previous_year_paper_repo import PreviousYearPaperRepo
+
+
+class SQLPreviousYearPaperRepo(PreviousYearPaperRepo):
+    def __init__(self, db: Session):
+        self.db = db
+
+    async def add_pdf_url(self, info: PreviousYearPaperAdd) -> PreviousYearPaper:
+        db_paper = PreviousYearPaperModel(
+            board=info.board,
+            subject=info.subject,
+            paper_code=info.paper_code,
+            paper_name=info.paper_name,
+            year=info.year,
+            file_url=info.file_url
+        )
+        self.db.add(db_paper)
+        self.db.commit()
+        self.db.refresh(db_paper)
+
+        return PreviousYearPaper.model_validate(db_paper)
+
+    async def get_all_pdf(self, skip: int, limit: int = 100) -> List[PreviousYearPaper]:
+        return self.db.query(PreviousYearPaperModel).offset(skip).limit(limit).all()

--- a/apps/backend/src/infrastructure/repo/previous_year_papers_repo.py
+++ b/apps/backend/src/infrastructure/repo/previous_year_papers_repo.py
@@ -1,7 +1,8 @@
 from typing import List
 from sqlalchemy.orm import Session
-from ...core.entities.previous_year_paper_entities import PreviousYearPaper, PreviousYearPaperAdd
+from ...utils.exceptions import NotFoundExceptionError
 from ...infrastructure.models.previous_year_papers_model import PreviousYearPaperModel
+from ...core.entities.previous_year_paper_entities import PreviousYearPaper, PreviousYearPaperAdd
 from ...core.repo.previous_year_paper_repo import PreviousYearPaperRepo
 
 
@@ -16,7 +17,10 @@ class SQLPreviousYearPaperRepo(PreviousYearPaperRepo):
             paper_code=info.paper_code,
             paper_name=info.paper_name,
             year=info.year,
-            file_url=info.file_url
+            file_url=info.file_url,
+            filename=info.filename,
+            public_id=info.public_id,
+            uploaded_by=info.uploaded_by
         )
         self.db.add(db_paper)
         self.db.commit()
@@ -26,3 +30,11 @@ class SQLPreviousYearPaperRepo(PreviousYearPaperRepo):
 
     async def get_all_pdf(self, skip: int, limit: int = 100) -> List[PreviousYearPaper]:
         return self.db.query(PreviousYearPaperModel).offset(skip).limit(limit).all()
+    
+    async def delete_pdf(self, id):
+        existing_file=self.db.query(PreviousYearPaperModel).filter(PreviousYearPaperModel.id==id).first()
+        if not existing_file:
+            raise NotFoundExceptionError(detail="PDF entry not found")
+        self.db.delete(existing_file)
+        self.db.commit()
+        return True

--- a/apps/backend/src/interfaces/routes/issues_routes.py
+++ b/apps/backend/src/interfaces/routes/issues_routes.py
@@ -39,14 +39,12 @@ async def report_issue(
             content_type=content_type)
         
 
-        # if temp_file_path and os.path.exists(temp_file_path):
-        #     os.remove(temp_file_path)
-        #     os.rmdir(temp_dir)
 
         if reported:
             return APIResponseSchema(success=True,
                 data = {"issue":reported},
                 message="issue reported, thanks for your contribution")
-        else: raise HTTPException(status_code=500, detail="Issue is not reported ")
+        else: 
+            raise HTTPException(status_code=500, detail="Issue is not reported ")
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/apps/backend/src/interfaces/routes/previous_year_paper_routes.py
+++ b/apps/backend/src/interfaces/routes/previous_year_paper_routes.py
@@ -1,0 +1,65 @@
+from sqlalchemy.orm import Session
+from fastapi import APIRouter, HTTPException,Depends
+from ...core.entities.previous_year_paper_entities import PreviousYearPaperAdd
+from ...core.entities.user_entities import User
+from ...core.services.file_uplaod_service import FileUploadService
+from ...core.services.previous_year_paper_service import previousYearPaperService
+from ...database.database import get_DB
+from ...infrastructure.repo.previous_year_papers_repo import SQLPreviousYearPaperRepo
+from ...interfaces.schemas.previous_years_schemas import UploadPDFSchema
+from ...interfaces.schemas.response_schemas import APIResponseSchema
+from ...interfaces.dependencies.dependencies import admin_or_super_admin_only
+
+prev_year_paper_router = APIRouter(prefix="/prev-year-pdf", tags=[""])
+
+@prev_year_paper_router.post("/upload",dependencies=[Depends(admin_or_super_admin_only)])
+async def upload_prev_year_pdf(
+    payload:UploadPDFSchema = Depends(UploadPDFSchema.as_form),
+    db: Session = Depends(get_DB),
+    ):
+    try:
+        if not payload.file.filename.lower().endswith(".pdf"):
+            raise HTTPException(status_code=400, detail="Only PDF files are allowed")
+
+
+        upload_service=FileUploadService()
+        prev_year_repo=SQLPreviousYearPaperRepo(db)
+        prev_year_service=previousYearPaperService(prev_year_repo)
+
+
+        file_url= await upload_service.upload_file(payload.file)
+        await prev_year_service.add_pdf_url(PreviousYearPaperAdd(
+            board=payload.board,
+            subject=payload.subject,
+            paper_code=payload.paper_code,
+            paper_name=payload.paper_name,
+            year=payload.year,
+            file_url=file_url
+        ))
+        return APIResponseSchema(
+            success=True,
+            data={"file_url": file_url},
+            message="PDF uploaded successfully"
+        )
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+
+@prev_year_paper_router.get("/all",dependencies=[Depends(admin_or_super_admin_only)])
+async def get_all_prev_year_pdfs(
+    skip:int=0,
+    limit:int=100,
+    db: Session = Depends(get_DB),
+    ):
+    try:
+        prev_year_repo=SQLPreviousYearPaperRepo(db)
+        prev_year_service=previousYearPaperService(prev_year_repo)
+        pdfs= await prev_year_service.get_all_pdf(skip,limit)
+        return APIResponseSchema(
+            success=True,
+            data={"pdfs": pdfs},
+            message="PDFs fetched successfully"
+        )
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))

--- a/apps/backend/src/interfaces/routes/user_routes.py
+++ b/apps/backend/src/interfaces/routes/user_routes.py
@@ -1,13 +1,10 @@
 from sqlalchemy.orm import Session
-from fastapi import APIRouter, HTTPException, Depends,UploadFile, File
-from fastapi.responses import JSONResponse
+from fastapi import APIRouter, HTTPException, Depends
 from ...database.database import get_DB
 from ...utils.security import SecurityManager
-from ...interfaces.schemas.previous_years_schemas import UploadPDFSchema
 from ...interfaces.schemas.user_schemas import UserDeleteSchema, UserRoleChangeSchema
 from ...core.entities.user_entities import User
 from ...core.services.user_service import UserService
-from ...core.services.file_uplaod_service import FileUploadService
 from ...infrastructure.repo.user_repo import SQLUserRepo
 from ...interfaces.schemas.response_schemas import APIResponseSchema
 from ...infrastructure.providers.auth_provider import get_security_manager
@@ -132,23 +129,5 @@ async def delete_user(
         raise HTTPException(status_code=400, detail=str(e))
     
 
-@user_router.post("/upload",dependencies=[Depends(admin_or_super_admin_only)])
-async def upload_pdf(
-    payload:UploadPDFSchema = Depends(UploadPDFSchema.as_form),
-    current_user: User = Depends(get_current_user)
-    ):
-    try:
-        if not payload.file.filename.lower().endswith(".pdf"):
-            raise HTTPException(status_code=400, detail="Only PDF files are allowed")
 
- 
-        upload_service=FileUploadService()
-        file_url= await upload_service.upload_file(payload.file)
-        return APIResponseSchema(
-            success=True,
-            message="File uploaded successfully",
-            data={"file_url":file_url}
-        )
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=str(e))
     

--- a/apps/backend/src/interfaces/schemas/previous_years_schemas.py
+++ b/apps/backend/src/interfaces/schemas/previous_years_schemas.py
@@ -1,0 +1,28 @@
+from typing import Optional
+from fastapi import UploadFile, File, Form
+from pydantic import BaseModel
+
+class UploadPDFSchema(BaseModel):
+    board: str
+    subject: str
+    paper_name: str
+    paper_code: str
+    year: int
+
+    @classmethod
+    def as_form(
+        cls,
+        board: str = Form(...),
+        subject: str = Form(...),
+        paper_name: str = Form(...),
+        paper_code: str = Form(...),
+        year: int = Form(...),
+        file: Optional[UploadFile] = File(None)
+    ):
+        return cls(
+            board=board,
+            subject=subject,
+            paper_name=paper_name,
+            paper_code=paper_code,
+            year=year
+        ), file

--- a/apps/backend/src/interfaces/schemas/previous_years_schemas.py
+++ b/apps/backend/src/interfaces/schemas/previous_years_schemas.py
@@ -8,7 +8,7 @@ class UploadPDFSchema(BaseModel):
     paper_name: str
     paper_code: str
     year: int
-
+    file: Optional[UploadFile] = None 
     @classmethod
     def as_form(
         cls,
@@ -24,5 +24,6 @@ class UploadPDFSchema(BaseModel):
             subject=subject,
             paper_name=paper_name,
             paper_code=paper_code,
-            year=year
-        ), file
+            year=year,
+            file=file
+        )

--- a/apps/backend/src/main.py
+++ b/apps/backend/src/main.py
@@ -13,6 +13,7 @@ from .interfaces.routes.otp_routes import otp_router
 from .interfaces.routes.user_routes import user_router
 from .interfaces.routes.feedback_routes import feedback_router
 from .interfaces.routes.issues_routes import issue_router
+from .interfaces.routes.previous_year_paper_routes import prev_year_paper_router
 from .config.config import settings
 
 
@@ -38,6 +39,7 @@ app.include_router(otp_router,prefix="/api")
 app.include_router(user_router,prefix="/api")
 app.include_router(feedback_router,prefix="/api")
 app.include_router(issue_router,prefix="/api")
+app.include_router(prev_year_paper_router,prefix="/api")
 
 # ROOT ROUTE
 @app.api_route("/health", methods=["GET", "HEAD"])


### PR DESCRIPTION
# 📄 PR Description

## Summary:
Added two backend endpoints for PDF upload and retrieval.

## 🚀 Changes Made

- Upload PDF Endpoint

Uploads PDF file (max size 5 MB) to Cloudinary.

Stores the file’s download URL and related metadata (board, subject, paper name, paper code, year) in PostgreSQL.

- Get Uploaded PDFs Endpoint

Returns a paginated list of uploaded PDFs.

Supports skip and limit query parameters for pagination.

## ⚙️ Implementation Details

Integrated Cloudinary SDK for file uploads.

Added file size and type validation.

